### PR TITLE
Add communication details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,33 @@
 # Ansible Community FDO Collection
 
-FDO solves a problem for building a chain of trust through managed infrastructure within an organization. Specifically, FDO solves: 
+FDO solves a problem for building a chain of trust through managed infrastructure within an organization. Specifically, FDO solves:
 
-- A problem of trust chain of the infrastructure. 
-- FDO takes care of the authentication and registration process of a new device. 
+- A problem of trust chain of the infrastructure.
+- FDO takes care of the authentication and registration process of a new device.
 - FDO authenticates/authorizes requests before enrolling and passing configuration to the existing devices.
 - There should be a secure channel for all the commands being issued to the device and between devices and FDO backend server.
 
 ---
 
 For collection usage examples see [this](./examples/README.md).
+
+## Communication
+
+Join the Ansible forum to ask questions, get help, and interact with us.
+
+- [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  Please add appropriate tags if you start new discussions.
+- [Social Spaces](https://forum.ansible.com/c/chat/4): meet and interact with
+  fellow enthusiasts.
+- [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide
+  announcements including social events.
+
+We announce releases and important changes through Ansible's [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn).
+
+For more information about communication, refer to the [Ansible Communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+
+## Code of Conduct
+
+We follow the [Ansible Code of Conduct](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html) in all our interactions within this project.
+
+If you encounter abusive behavior, please refer to the [policy violations](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html#policy-violations) section of the Code for information on how to raise a complaint.


### PR DESCRIPTION
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thanks!