### PR TITLE
Added support for using DNS for RV INFO in manufacturing config & owner address in owner server config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tests/output
 tests/integration/integration_config.yml
 tests/integration/inventory
 ansible_collections
+.vscode

--- a/roles/configure_manufacturing_server/defaults/main.yml
+++ b/roles/configure_manufacturing_server/defaults/main.yml
@@ -17,6 +17,7 @@ manufacturing_server_protocols_diun_key_path: "{{ fdo_src }}/keys/diun_key.der"
 manufacturing_server_protocols_diun_cert_path: "{{ fdo_src }}/keys/diun_cert.pem"
 manufacturing_server_rendezvous_info_deviceport: 8082
 manufacturing_server_rendezvous_info_ip_address: 127.0.0.1 # change to rendezvous server ip
+manufacturing_server_rendezvous_info_dns: ""
 manufacturing_server_rendezvous_info_owner_port: "{{ manufacturing_server_rendezvous_info_deviceport }}"
 manufacturing_server_rendezvous_info_protocol: http
 manufacturing_server_manufacturing_manufacturer_cert_path: "{{ fdo_src }}/keys/manufacturer_cert.pem"

--- a/roles/configure_manufacturing_server/templates/manufacturing-server.yml.j2
+++ b/roles/configure_manufacturing_server/templates/manufacturing-server.yml.j2
@@ -21,7 +21,11 @@ protocols:
     cert_path: {{ manufacturing_server_protocols_diun_cert_path }}
 rendezvous_info:
   - deviceport: {{ manufacturing_server_rendezvous_info_deviceport }}
+{% if manufacturing_server_rendezvous_info_dns is defined and manufacturing_server_rendezvous_info_dns | length > 0 %}
+    dns: {{ manufacturing_server_rendezvous_info_dns }}
+{% else %} 
     ip_address: {{ manufacturing_server_rendezvous_info_ip_address }}
+{% endif %}
     ownerport: {{ manufacturing_server_rendezvous_info_owner_port }}
     protocol: {{ manufacturing_server_rendezvous_info_protocol }}
 manufacturing:

--- a/roles/configure_owner_server/defaults/main.yml
+++ b/roles/configure_owner_server/defaults/main.yml
@@ -19,6 +19,7 @@ owner_onboarding_server_listen_port_owner_onboarding_server: 8081
 owner_onboarding_server_listen_port_serviceinfo_api_server: 8083
 owner_onboarding_server_service_info_api_authentication_token: TestAuthToken # change to a valid API token
 owner_onboarding_server_owner_addresses_transport: http
+owner_onboarding_server_owner_addresses_dns_name: ""
 owner_onboarding_server_owner_addresses_ip_address: 127.0.0.1 # change to owner server ip
 owner_onboarding_server_report_to_rendezvous_endpoint_enabled: true
 

--- a/roles/configure_owner_server/templates/owner-onboarding-server.yml.j2
+++ b/roles/configure_owner_server/templates/owner-onboarding-server.yml.j2
@@ -16,6 +16,10 @@ service_info_api_authentication:
 owner_addresses:
   - transport: {{ owner_onboarding_server_owner_addresses_transport }}
     addresses:
+{% if owner_onboarding_server_owner_addresses_dns_name is defined and owner_onboarding_server_owner_addresses_dns_name | length > 0 %}
+      - dns_name: {{ owner_onboarding_server_owner_addresses_dns_name }}
+{% else %}
       - ip_address: {{ owner_onboarding_server_owner_addresses_ip_address }}
+{% endif %}
     port: {{ owner_onboarding_server_listen_port_owner_onboarding_server }}
 report_to_rendezvous_endpoint_enabled: {{ owner_onboarding_server_report_to_rendezvous_endpoint_enabled | bool | lower }}


### PR DESCRIPTION
Updated manufacturing server config file template to allow using RV server dns under RV_INFO also updated the config file template for owner server to use owner server dns name 
